### PR TITLE
Formatting + tweaks

### DIFF
--- a/pipelines.md
+++ b/pipelines.md
@@ -25,6 +25,7 @@ async Task AcceptAsync(Socket socket)
     var stream = new NetworkStream(socket);
     var buffer = new byte[1024];
     await stream.ReadAsync(buffer, 0, buffer.Length);
+    // Parse data
     ProcessLine(buffer);
 }
 ```
@@ -51,6 +52,7 @@ async Task AcceptAsync(Socket socket)
 
         if (lineLength >= 0)
         {
+            // Parse data
             ProcessLine(buffer, 0, lineLength);
             read = 0;
         }
@@ -90,6 +92,7 @@ async Task AcceptAsync(Socket socket)
 
         if (lineLength >= 0) 
         {
+            // Parse data
             ProcessLine(buffer, 0, lineLength);
             read = 0;
         }
@@ -135,6 +138,7 @@ async Task AcceptAsync(Socket socket)
         {
             buffers.Add(new ArraySegment<byte>(buffer, 0, lineLength));
 
+            // Parse data
             ProcessLine(buffers);
 
             buffers.Clear();
@@ -183,6 +187,7 @@ async Task AcceptAsync(Socket socket)
         {
             buffers.Add(new ArraySegment<byte>(buffer, 0, lineLength));
 
+            // Parse data
             ProcessLine(buffers);
 
             foreach (var buffer buffers) 
@@ -257,6 +262,7 @@ async Task AcceptAsync(Socket socket)
 
             if (position != null)
             {
+                // Parse data
                 ProcessLine(buffer.Slice(0, position.Value));
                 buffer = buffer.Slice(buffer.GetPosition(1, position.Value));
             }

--- a/pipelines.md
+++ b/pipelines.md
@@ -286,9 +286,9 @@ The pipelines version of our line reader has 2 loops:
 - One loop reads from the `Socket` and writes into the `PipeWriter`.
 - The other loop reads from the `PipeReader` and parses incoming lines.
 
-Unlike the original examples, there are no explicit buffers allocated anywhere. This is one of pipelines' core features. 
+Unlike the original examples, there are no explicit buffers allocated anywhere. This is one of pipelines' core features. All buffer management is delegated to the `PipeReader`/`PipeWriter` implementations. 
 
-All buffer management is delegated to the `PipeReader`/`PipeWriter` implementations. This makes it easier for consuming code to focus solely on the business logic instead of complex buffer management. 
+**This makes it easier for consuming code to focus solely on the business logic instead of complex buffer management.** 
 
 In the first loop, we first call `PipeWriter.GetMemory(int)` to get some memory from the underlying writer then we call `PipeWriter.Advance(int)` to tell the `PipeWriter` how much data we actually wrote to the buffer. We then call `PipeWriter.FlushAsync()` to make the data available to the `PipeReader`.
 

--- a/pipelines.md
+++ b/pipelines.md
@@ -296,15 +296,6 @@ In the second loop, we're consuming the buffers written by the `PipeWriter` whic
 
 At the end of each of the loops, we complete both the reader and the writer. This lets the underlying `Pipe` release all of the memory it allocated.
 
-### Efficent Generalization
-
-If parsing line delimited files was a common pattern; rather than having a specific `ProcessLine` method for one type of parsing, its easy enough to generalize the above just by adding a `Action<ReadOnlySequence<byte>> ProcessLine` parameter to the method signiture:
-```C#
-async Task AcceptAsync(Socket socket, Action<ReadOnlySequence<byte>> ProcessLine)
-```
-
-Now extracting lines from a `Socket` is self-contained and could be turned into a library method and cope with all types of line parsing by just passing a different method in as the `Action`.
-
 ## System.IO.Pipelines
 
 ### Partial Reads

--- a/pipelines.md
+++ b/pipelines.md
@@ -29,7 +29,9 @@ async Task AcceptAsync(Socket socket)
 }
 ```
 
-This code might work when testing locally but it's broken because the entire message (end of line) may not have been received in a single call to `ReadAsync`. Even worse, we're failing to look at the result of `stream.ReadAsync()` which returns how much data was actually filled into the buffer. This is a common mistake when using `Stream` today. To account for this, we need to buffer the incoming data until we have found a new line.
+This code might work when testing locally but it's broken because the entire message (end of line) may not have been received in a single call to `ReadAsync`. Even worse, we're failing to look at the result of `stream.ReadAsync()` which returns how much data was actually filled into the buffer. 
+
+This is a common mistake when using `Stream` today. To account for this, we need to buffer the incoming data until we have found a new line:
 
 ```C#
 async Task AcceptAsync(Socket socket)
@@ -56,7 +58,7 @@ async Task AcceptAsync(Socket socket)
 }
 ```
 
-Once again, this might work in local testing but it's possible that the line is bigger than 1KiB (1024 bytes). So we need to resize the input buffer until we have found a new line.
+Once again, this might work in local testing but it's possible that the line is bigger than 1KiB (1024 bytes). So we need to resize the input buffer until we have found a new line:
 
 ```C#
 async Task AcceptAsync(Socket socket)
@@ -95,7 +97,9 @@ async Task AcceptAsync(Socket socket)
 }
 ```
 
-This code works but now we're re-sizing the buffer which causes extra allocations and copies. To avoid this, we can store a list of buffers instead of resizing each time we cross the 1KiB buffer size. We're also re-using the 1KiB buffer until it's completely empty. This means we can end up passing smaller and smaller buffers to `ReadAsync` which will result in more calls into the operating system. To mitigate this, we'll allocate a new buffer when there's less than 512 bytes remaining in the existing buffer.
+This code works but now we're re-sizing the buffer which causes extra allocations and copies. To avoid this, we can store a list of buffers instead of resizing each time we cross the 1KiB buffer size. We're also re-using the 1KiB buffer until it's completely empty. This means we can end up passing smaller and smaller buffers to `ReadAsync` which will result in more calls into the operating system. 
+
+To mitigate this, we'll allocate a new buffer when there's less than 512 bytes remaining in the existing buffer:
 
 ```C#
 async Task AcceptAsync(Socket socket)
@@ -141,7 +145,9 @@ async Task AcceptAsync(Socket socket)
 
 This code just got much more complicated. We're keeping track the filled up buffers as we're looking for the delimeter. To do this, we're using a `List<ArraySegment<byte>>` here to represent the buffered data while looking for the new line delimeter. As a result, `ProcessLine` now accepts a `List<ArraySegment<byte>>` instead of a `byte[]`, `offset` and `count`. Our parsing logic needs to now handle one or more buffer segments.
 
-There's another optimization that we need to make before we call this server complete. Right now we have a bunch of heap allocated buffers in a list. We can improve the allocations by using the `ArrayPool<byte>` to avoid repeated buffer allocations as we're parse more lines from the client. 
+There's another optimization that we need to make before we call this server complete. Right now we have a bunch of heap allocated buffers in a list. 
+
+We can improve the allocations by using the `ArrayPool<byte>` to avoid repeated buffer allocations as we're parse more lines from the client: 
 
 ```C#
 async Task AcceptAsync(Socket socket)
@@ -201,23 +207,25 @@ Our server now handles partial messages, and it uses pooled memory to reduce ove
     - The memory management logic is now spread across 2 different pieces of code, the code that rents from the buffer pool is reading from the socket and the code that returns from the buffer pool is the parsing logic.
     - We need to be extremely careful with how we return buffers after the parsing logic is done with them. If we're not careful, it's possible that we return a buffer that's still being written to by the `Socket` reading logic.
 
-The complexity has gone through the roof (and we haven't even covered all of the cases). High performance networking usually means writing very complex code in order to eke out more performance from the system. The goal of System.IO.Pipelines is to make writing this type of code easier.
+The complexity has gone through the roof (and we haven't even covered all of the cases). High performance networking usually means writing very complex code in order to eke out more performance from the system. 
+
+The goal of `System.IO.Pipelines` is to make writing this type of code easier.
 
 ### TCP server with System.IO.Pipelines
 
-Let's take a look at what this example looks like with System.IO.Pipelines.
+Let's take a look at what this example looks like with `System.IO.Pipelines`:
 
 ```C#
 async Task AcceptAsync(Socket socket)
 {
     var pipe = new Pipe();
-    Task writing = ReadFromSocketAsync(pipe.Writer);
+    Task writing = ReadFromSocketAsync(socket, pipe.Writer);
     Task reading = ReadFromPipeAsync(pipe.Reader);
 
-    async Task ReadFromSocketAsync(PipeWriter writer)
+    async Task ReadFromSocketAsync(Socket input, PipeWriter writer)
     {
         const int minimumBufferSize = 512;
-        
+
         while (true)
         {
             Memory<byte> memory = writer.GetMemory(minimumBufferSize);
@@ -227,13 +235,14 @@ async Task AcceptAsync(Socket socket)
                 break;
             }
             writer.Advance(read);
-            FlushResult result = await writer.FlushAync();
-            
-            if (result.IsCompleted) 
+            FlushResult result = await writer.FlushAsync();
+
+            if (result.IsCompleted)
             {
                 break;
             }
         }
+
         writer.Complete();
     }
 
@@ -271,7 +280,11 @@ The pipelines version of our line reader has 2 loops:
 - One loop reads from the `Socket` and writes into the `PipeWriter`.
 - The other loop reads from the `PipeReader` and parses incoming lines.
 
-Unlike the original examples, there are no explicit buffers allocated anywhere. This is one of pipelines' core features. All buffer management is delegated to the `PipeReader`/`PipeWriter` implementations. This makes it easier for consuming code to focus solely on the business logic instead of complex buffer management. In the first loop, we first call `PipeWriter.GetMemory(int)` to get some memory from the underlying writer then we call `PipeWriter.Advance(int)` to tell the `PipeWriter` how much data we actually wrote to the buffer. We then call `PipeWriter.FlushAsync()` to make the data available to the `PipeReader`.
+Unlike the original examples, there are no explicit buffers allocated anywhere. This is one of pipelines' core features. 
+
+All buffer management is delegated to the `PipeReader`/`PipeWriter` implementations. This makes it easier for consuming code to focus solely on the business logic instead of complex buffer management. 
+
+In the first loop, we first call `PipeWriter.GetMemory(int)` to get some memory from the underlying writer then we call `PipeWriter.Advance(int)` to tell the `PipeWriter` how much data we actually wrote to the buffer. We then call `PipeWriter.FlushAsync()` to make the data available to the `PipeReader`.
 
 In the second loop, we're consuming the buffers written by the `PipeWriter` which ultimately comes from the `Socket`. When the call to `PipeReader.ReadAsync()` returns, we get a `ReadResult` which contains 2 important pieces of information, the data that was read in the form of `ReadOnlySequence<byte>` and a bool `IsCompleted` that lets the reader know if the writer is done writing (EOF). After finding the line end delimeter and parsing the line, we slice the buffer to skip what we've already processed and then we call `PipeReader.AdvanceTo` to tell the `PipeReader` how much data we have both consumed and observed. 
 
@@ -281,19 +294,29 @@ At the end of each of the loops, we complete both the reader and the writer. Thi
 
 ### Partial Reads
 
-Besides handling the memory management, the other core pipelines feature is the ability to peek at data in the `Pipe` without actually reading it. `PipeReader` has 2 core APIs `ReadAsync` and `AdvanceTo`. `ReadAsync` gets the data in the `Pipe`, `AdvanceTo` does a couple of things, it tells the `PipeReader` that these buffers are no longer required by the reader so they can be discarded (for example returned to the underlying buffer pool). It also allows the reader to tell the `PipeReader` "don't wake me up again until there's more data available". This is important for the performance of the reader as it means the reader won't be signalled until there's more data than was previously marked "observed".
+Besides handling the memory management, the other core pipelines feature is the ability to peek at data in the `Pipe` without actually consuming it ("observed" data). 
+
+`PipeReader` has 2 core APIs `ReadAsync` and `AdvanceTo`. `ReadAsync` gets the data in the `Pipe`, `AdvanceTo` does a couple of things, it tells the `PipeReader` that these buffers are no longer required by the reader so they can be discarded (for example returned to the underlying buffer pool). 
+
+It also allows the reader to tell the `PipeReader` "don't wake me up again until there's more data available". This is important for the performance of the reader as it means the reader won't be signalled until there's more data than was previously marked "observed".
 
 ### Back pressure and flow control
 
-As mentioned previously, one of the challenges of de-coupling the parsing thread from the reading thread is the fact that we may end up buffering too much data if the parsing thread can't keep up with the reading thread. To solve this problem, the pipe has 2 settings to control the flow of data, the `PauseWriterThreshold` and the `ResumeWriterThreshold`. The `PauseWriterThreshold` determines how much data should be buffered before calls to `PipeWriter.FlushAsync` returns an incomplete `ValueTask`. The `ResumeWriterThreshold` controls how much the reader has to consume before writing can resume (the ValueTask returned from `PipeWriter.FlushAsync` is marked as complete).
+As mentioned previously, one of the challenges of de-coupling the parsing thread from the reading thread is the fact that we may end up buffering too much data if the parsing thread can't keep up with the reading thread. 
+
+To solve this problem, the pipe has 2 settings to control the flow of data, the `PauseWriterThreshold` and the `ResumeWriterThreshold`. The `PauseWriterThreshold` determines how much data should be buffered before calls to `PipeWriter.FlushAsync` returns an incomplete `ValueTask`. The `ResumeWriterThreshold` controls how much the reader has to consume before writing can resume (the ValueTask returned from `PipeWriter.FlushAsync` is marked as complete).
 
 ![image](https://user-images.githubusercontent.com/95136/42291183-0114a0f2-7f7f-11e8-983f-5332b7585a09.png)
 
-`PipeWriter.FlushAsync` "blocks" when amount of data in `Pipe` crosses `PauseWriterThreshold`  and "unblocks" when it becomes lower then `ResumeWriterThreshold`. Two values are used to prevent thrashing around the limit.
+`PipeWriter.FlushAsync` "blocks" when amount of data in `Pipe` crosses `PauseWriterThreshold` and "unblocks" when it becomes lower then `ResumeWriterThreshold`. Two values are used to prevent thrashing around the limit.
 
 ### Scheduling IO
 
-Usually when using async/await, continuations are called on either on thread pool threads or on the current `SynchronizationContext`. When doing IO it's very important to have fine grained control over where that IO is performed and pipelines exposes a `PipeScheduler` that determines where asynchronous callbacks run. This gives the caller fine grained control over exactly what threads are used for IO. An example of this in practice is in the Kestrel Libuv transport where IO callbacks run on dedicated event loop threads.
+Usually when using async/await, continuations are called on either on thread pool threads or on the current `SynchronizationContext`. 
+
+When doing IO it's very important to have fine grained control over where that IO is performed and pipelines exposes a `PipeScheduler` that determines where asynchronous callbacks run. This gives the caller fine grained control over exactly what threads are used for IO. 
+
+An example of this in practice is in the Kestrel Libuv transport where IO callbacks run on dedicated event loop threads.
 
 ### ReadOnlySequence\<T\>
 
@@ -301,7 +324,11 @@ The `Pipe` implementation stores a linked list of buffers that get passed betwee
 
 ![image](https://user-images.githubusercontent.com/95136/42292592-74a4028e-7f88-11e8-85f7-a6b2f925769d.png)
 
-The `Pipe` internally maintains pointers to where the reader and writer are in the overall set of allocated data and updates them as data is written or read. The `SequencePosition` represents a single point in the linked list of buffers and can be used to efficiently Slice the `ReadOnlySequence<T>`. Since the `ReadOnlySequence<T>` can support one or more segments, it's typical for high performance processing logic to split fast and slow paths based on single or multiple segments. For example, here's a routine that converts an ASCII `ReadOnlySequence<byte>` into a `string`:
+The `Pipe` internally maintains pointers to where the reader and writer are in the overall set of allocated data and updates them as data is written or read. The `SequencePosition` represents a single point in the linked list of buffers and can be used to efficiently Slice the `ReadOnlySequence<T>`. 
+
+Since the `ReadOnlySequence<T>` can support one or more segments, it's typical for high performance processing logic to split fast and slow paths based on single or multiple segments. 
+
+For example, here's a routine that converts an ASCII `ReadOnlySequence<byte>` into a `string`:
 
 ```C#
 string GetAsciiString(ReadOnlySequence<byte> buffer)
@@ -339,6 +366,8 @@ As part of making System.IO.Pipelines, we also added a number of new primitive B
 
 ## How do I use them?
 
-The APIs exist in the [System.IO.Pipelines](https://www.nuget.org/packages/System.IO.Pipelines/) nuget package. Here's an example of a .NET Core 2.1 server application that uses pipelines to handle line based messages (our example above) https://github.com/davidfowl/TcpEcho. It should run with `dotnet run` (or by running it in Visual Studio). It listens to a socket on port 8087 and writes out received messages to the console. You can use a client like netcat or putty to make a connection to 8087 and send line based messages to see it working.
+The APIs exist in the [System.IO.Pipelines](https://www.nuget.org/packages/System.IO.Pipelines/) nuget package. H
+
+ere's an example of a .NET Core 2.1 server application that uses pipelines to handle line based messages (our example above) https://github.com/davidfowl/TcpEcho. It should run with `dotnet run` (or by running it in Visual Studio). It listens to a socket on port 8087 and writes out received messages to the console. You can use a client like netcat or putty to make a connection to 8087 and send line based messages to see it working.
 
 Today Pipelines powers Kestrel and SignalR and we hope to see it at the center of many networking libraries and components from the .NET community. 

--- a/pipelines.md
+++ b/pipelines.md
@@ -214,7 +214,7 @@ Our server now handles partial messages, and it uses pooled memory to reduce ove
 
 The complexity has gone through the roof (and we haven't even covered all of the cases). High performance networking usually means writing very complex code in order to eke out more performance from the system. 
 
-The goal of `System.IO.Pipelines` is to make writing this type of code easier.
+*The goal of `System.IO.Pipelines` is to make writing this type of code easier.*
 
 ### TCP server with System.IO.Pipelines
 

--- a/pipelines.md
+++ b/pipelines.md
@@ -296,6 +296,15 @@ In the second loop, we're consuming the buffers written by the `PipeWriter` whic
 
 At the end of each of the loops, we complete both the reader and the writer. This lets the underlying `Pipe` release all of the memory it allocated.
 
+### Efficent Generalization
+
+If parsing line delimited files was a common pattern; rather than having a specific `ProcessLine` method for one type of parsing, its easy enough to generalize the above just by adding a `Action<ReadOnlySequence<byte>> ProcessLine` parameter to the method signiture:
+```C#
+async Task AcceptAsync(Socket socket, Action<ReadOnlySequence<byte>> ProcessLine)
+```
+
+Now extracting lines from a `Socket` is self-contained and could be turned into a library method and cope with all types of line parsing by just passing a different method in as the `Action`.
+
 ## System.IO.Pipelines
 
 ### Partial Reads
@@ -372,8 +381,8 @@ As part of making System.IO.Pipelines, we also added a number of new primitive B
 
 ## How do I use them?
 
-The APIs exist in the [System.IO.Pipelines](https://www.nuget.org/packages/System.IO.Pipelines/) nuget package. H
+The APIs exist in the [System.IO.Pipelines](https://www.nuget.org/packages/System.IO.Pipelines/) nuget package. 
 
-ere's an example of a .NET Core 2.1 server application that uses pipelines to handle line based messages (our example above) https://github.com/davidfowl/TcpEcho. It should run with `dotnet run` (or by running it in Visual Studio). It listens to a socket on port 8087 and writes out received messages to the console. You can use a client like netcat or putty to make a connection to 8087 and send line based messages to see it working.
+Here's an example of a .NET Core 2.1 server application that uses pipelines to handle line based messages (our example above) https://github.com/davidfowl/TcpEcho. It should run with `dotnet run` (or by running it in Visual Studio). It listens to a socket on port 8087 and writes out received messages to the console. You can use a client like netcat or putty to make a connection to 8087 and send line based messages to see it working.
 
 Today Pipelines powers Kestrel and SignalR and we hope to see it at the center of many networking libraries and components from the .NET community. 


### PR DESCRIPTION
nits

Also `FlushAsync` was spelt wrong and best to pass `Socket` into the async local function

/cc @davidfowl 